### PR TITLE
精简依赖，使用 slf4j-api 代替 log4j-slf4j-impl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,9 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <version>2.20.0</version>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.7</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/rapidocr-common/pom.xml
+++ b/rapidocr-common/pom.xml
@@ -25,8 +25,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
我在启动项目的时候，出现了这样的警告。
因为我项目里用的是 logback ，在添加 RapidOcr-Java 后，又新加了一个 log4j 的依赖。
希望删除对 log4j 的依赖

SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:.../slf4j-log4j12-1.7.21.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:.../logback-classic-1.1.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.