### PR TITLE
加入 linux arm64 支持模块 rapidocr-onnx-linux-arm64

### DIFF
--- a/docs/Build_Rapid_OCR_Onnx_Lib_on_Kylin_arm64.md
+++ b/docs/Build_Rapid_OCR_Onnx_Lib_on_Kylin_arm64.md
@@ -1,0 +1,333 @@
+# Build Rapid OCR Onnx Lib on Kylin(arm64 )
+
+### 原始环境信息
+
+操作系统: 银河麒麟 V10(SP1)
+
+CPU： Phytium,D2000/8 E8C    (指令集: arm64)
+
+内存:  8G
+
+
+
+gcc 版本：9.3
+
+cmake 版本：3.16.1
+
+缺少 g++
+
+
+
+### 编译要求
+
+gcc > 7
+
+g++ > 7
+
+cmake > 3.17
+
+
+
+
+
+### 环境准备
+
+如果没有银河麒麟麒麟的源，需要配一下
+
+源地址：http://archive.kylinos.cn/kylin/KYLIN-ALL/
+
+```sh          
+在系统的/etc/apt/sources.list文件中，根据不同版本填入以下内容
+
+#4.0.2桌面版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2-desktop main restricted universe multiverse
+
+#4.0.2-sp1桌面版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2sp1-desktop main restricted universe multiverse
+
+#4.0.2-sp2桌面版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2sp2-desktop main restricted universe multiverse
+
+#4.0.2服务器版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2-server main restricted universe multiverse
+
+#4.0.2-sp1服务器版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2sp1-server main restricted universe multiverse
+
+#4.0.2-sp2服务器版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2sp2-server main restricted universe multiverse
+
+#4.0.2-sp2 FT2000+服务器版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2sp2-server-ft2000 main restricted universe multiverse
+
+#4.0.2-sp3版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2sp3 main restricted universe multiverse
+
+#4.0.2-sp4版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 4.0.2sp4 main restricted universe multiverse
+
+#V10版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 10.0 main restricted universe multiverse
+
+#V10.1版本:
+deb http://archive.kylinos.cn/kylin/KYLIN-ALL 10.1 main restricted universe multiverse
+
+```
+
+
+
+
+
+#### 使用 apt install 下载 deb 包
+
+也可以直接 install，下载的目的是方便以后可以把需要的包离线传输到内网机器安装
+
+```sh          
+sudo apt install --download-only <package>
+
+# 下载后的包缓存在在 /var/cache/apt/packages 目录下
+```
+
+
+
+#### 下载并安装 gcc
+
+下载
+
+```sh          
+sudo apt install --download-only  gcc
+
+#进入 /var/cache/apt/packages
+cd /var/cache/apt/packages
+
+```
+
+
+
+下载到的包
+
+```sh
+#下载到以下包(不同机器拿到的包应该不一样)
+ls
+gcc_4%3a9.3.0-11.185.1kylin2k7.5_arm64.deb
+```
+
+
+
+安装
+
+```sh
+#可以复制到其他位置备用
+sudo cp *.deb /home/some/pkgs/gcc
+
+#安装 deb 包
+sudo dpkg -i *.deb
+
+#安装完成后清一下 /var/cache/apt/packages
+sudo rm -rf .  #小心一些，确保当前目录是 /var/cache/apt/packages
+
+#查看 gcc 版本
+gcc --version
+```
+
+
+
+
+
+
+
+#### 下载并安装 g++
+
+```sh          
+sudo apt install --download-only  g++
+
+
+#进入 /var/cache/apt/packages
+cd /var/cache/apt/packages
+
+#下载到以下包(不同机器拿到的包应该不一样)
+ls
+g++_4%3a9.3.0-11.185.1kylin2k7.5_arm64.deb
+g++-9_9.3.0-10kylin2_arm64.deb
+libstdc++-9-dev_9.3.0-10kylin2_arm64.deb
+
+#可以复制到其他位置备用
+sudo cp *.deb /home/some/pkgs/g++
+
+#安装 deb 包
+sudo dpkg -i *.deb
+
+#安装完成后清一下 /var/cache/apt/packages
+sudo rm -rf .  #小心一些，确保当前目录是 /var/cache/apt/packages
+
+#查看 g++ 版本
+g++ --version
+```
+
+
+
+g++ 包
+
+```sh
+g++_4%3a9.3.0-11.185.1kylin2k7.5_arm64.deb
+g++-9_9.3.0-10kylin2_arm64.deb
+libstdc++-9-dev_9.3.0-10kylin2_arm64.deb
+```
+
+
+
+#### 下载并安装 cmake
+
+使用 apt install 装的 cmake 最高版本是 3.16 不符合要求
+
+从 cmake 官网下载 https://cmake.org/download/  找到 Linux aarch64 版本下载 tar.gz 包
+
+```sh          
+# 将 tar.gz 包复制到用户目录下
+# 解压 cmake-3.29.2-linux-aarch64.tar.gz 例如释放到：/home/some/soft/cmake
+
+vim ~/.bashrc
+# 在最后加上：
+export PATH=$PATH:/home/some/soft/cmake/bin
+
+source ~/.bashrc
+
+which cmake
+
+#显示 cmake 的版本
+cmake -version 
+```
+
+
+
+#### 下载并配置 JVM
+
+jvm 是用来构建 jni 的时候需要的，去 oracle 官网下载 aarch64 版本的压缩包即可。
+
+
+
+配置环境变量
+
+```sh
+# 将 jdk 解压缩到指定目录,例如 /home/some/soft/jdk
+# 在最后加上：
+export JAVA_HOME=/home/some/soft/jdk  # JAVA_HOME 一定要设,否则后面编译 JNI 时会找不到
+export PATH=$PATH:$JAVA_HOME/bin
+
+source ~/.bashrc
+
+
+#验证 jdk
+java -version
+```
+
+
+
+
+
+
+
+
+
+### 下载源码并构建
+
+根据 https://github.com/RapidAI/RapidOcrOnnx/blob/main/BUILD.md 编译说明开始编译
+
+下面内容和原文基本符合，着重说明实际银河麒麟 kylin linux 的编译过程。
+
+
+
+#### 下载源码
+
+项目地址：https://github.com/RapidAI/RapidOcrOnnx/，下载源码并复制到目标机器上
+
+
+
+#### 依赖的第三方库下载
+
+下载opencv，[下载地址](https://github.com/RapidAI/OpenCVBuilder/releases)
+
+- OpenCV静态库：opencv-(版本号)-平台.7z
+
+```sh
+opencv-static
+├── OpenCVWrapperConfig.cmake
+├── linux
+```
+
+实际编译下载版本为：opencv-4.8.1-ubuntu-18.04-arm64-java.7z
+
+
+
+下载onnxruntime，[下载地址](https://github.com/RapidAI/OnnxruntimeBuilder/releases)
+
+- static为静态库：onnxruntime-(版本号)-平台-static.7z
+- shared为动态库：onnxruntime-(版本号)-平台-shared.7z
+- 一般情况下使用静态库即可
+
+```
+onnxruntime-static
+├── OnnxRuntimeWrapper.cmake
+├── linux
+
+```
+
+实际编译下载版本为：onnxruntime-v1.15.1-ubuntu-18.04-arm64-static.7z
+
+
+
+#### 编译构建
+
+g++>=5，cmake>=3.17[下载地址](https://cmake.org/download/)
+
+* 终端打开项目根目录，`./build.sh`并按照提示输入选项，**最后选择'BIN可执行文件'**
+
+
+
+**注意!!!  直接执行很可能会出现编译错误：**
+
+```
+fatal error: onnxruntime.core.session.onnxruntime_cxx_api.h 没有那个文件或目录
+#include <onnxruntime.core.session.onnxruntime_cxx_api.h>
+```
+
+
+
+受影响的文件有 include 目录下的文件: `AngleNet.h`  `CrnnNet.h`  `DbNet.h`  `OcrLite.h` `OcrUtils.h`
+
+```c++
+// 将下面的代码
+#include <onnxruntime/core/session/onnxruntime_cxx_api.h>
+//改为
+#include <onnxruntime/onnxruntime_cxx_api.h> // rapidOcr 作者建议的版本(暂时没验证)
+
+#include <onnxruntime_cxx_api.h>  // kylin 编译时实际修改的版本
+```
+
+
+
+这个问题在编译 MacOS 版本的动态库时也会遇到，参考：https://github.com/MyMonsterCat/RapidOcr-Java/blob/main/docs/COMPILE_LIB.md
+
+
+
+* 测试：`./run-test.sh`(注意修改脚本内的目标图片路径)
+
+* 编译JNI动态运行库(可选，可用于java调用)
+
+- 下载jdk-8u221并安装配置
+- 运行`build.sh`并按照提示输入选项，**最后选择'JNI动态库'**
+- **注意：编译JNI时，g++版本要求>=6**
+
+
+
+### 参考链接
+
+https://github.com/RapidAI/RapidOCR
+
+https://github.com/RapidAI/RapidOcrOnnx
+
+https://github.com/MyMonsterCat/RapidOcr-Java
+
+https://onnxruntime.ai/
+
+https://github.com/RapidAI/RapidOcrOnnx/blob/main/BUILD.md

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>rapidocr-ncnn-macosx-x86_64</module>
         <module>rapidocr-ncnn-linux-x86_64</module>
         <module>rapidocr-ncnn-windows-x86_64</module>
+        <module>rapidocr-onnx-linux-arm64</module>
 
     </modules>
 
@@ -106,6 +107,11 @@
             <dependency>
                 <groupId>io.github.mymonstercat</groupId>
                 <artifactId>rapidocr-onnx-windows-x86</artifactId>
+                <version>${model.version.122}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.mymonstercat</groupId>
+                <artifactId>rapidocr-onnx-linux-arm64</artifactId>
                 <version>${model.version.122}</version>
             </dependency>
             <!--      NCNN       -->

--- a/rapidocr-onnx-linux-arm64/pom.xml
+++ b/rapidocr-onnx-linux-arm64/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.mymonstercat</groupId>
+        <artifactId>rapidocr-java</artifactId>
+        <version>0.0.7</version>
+    </parent>
+
+    <artifactId>rapidocr-onnx-linux-arm64</artifactId>
+    <version>1.2.2</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.mymonstercat</groupId>
+            <artifactId>rapidocr-onnx-models</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/rapidocr-onnx-linux-arm64/src/main/java/io/github/mymonstercat/OnnxLinuxArm64LibraryLoader.java
+++ b/rapidocr-onnx-linux-arm64/src/main/java/io/github/mymonstercat/OnnxLinuxArm64LibraryLoader.java
@@ -1,0 +1,16 @@
+package io.github.mymonstercat;
+
+import io.github.mymonstercat.loader.LibraryLoader;
+
+import java.io.IOException;
+
+/**
+ * @author sandywalker
+ * @since 2024-4-30
+ */
+public class OnnxLinuxArm64LibraryLoader implements LibraryLoader {
+    @Override
+    public void loadLibrary() throws IOException {
+        JarFileUtil.copyFileFromJar("lib/libRapidOcr.so", "/onnx", true, false);
+    }
+}

--- a/rapidocr-onnx-platform/pom.xml
+++ b/rapidocr-onnx-platform/pom.xml
@@ -109,6 +109,21 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>linux-arm64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>arm64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.github.mymonstercat</groupId>
+                    <artifactId>rapidocr-onnx-linux-arm64</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
 
 
     </profiles>

--- a/rapidocr/src/main/java/io/github/mymonstercat/ocr/LoadUtil.java
+++ b/rapidocr/src/main/java/io/github/mymonstercat/ocr/LoadUtil.java
@@ -45,9 +45,15 @@ public class LoadUtil {
             } else if (osName.contains("linux")) {
                 if (osArch.contains("x86") || osArch.contains("amd64")) {
                     loaderClassName = props.getProperty(engine + ".linux-x86_64");
-                } else if (osArch.contains("arm")) {
-                    loaderClassName = props.getProperty("linuxArmLoader");
                 }
+//begin sandywalker 2024-04-30 add arm64 linux support
+//                else if (osArch.contains("arm")) {
+//                    loaderClassName = props.getProperty("linuxArmLoader");
+//                }
+                else if (osArch.contains("arm") || osArch.contains("arch64")){
+                    loaderClassName = props.getProperty(engine + ".linux-arm64");  //Note: only support onnx,  not support ncnn now
+                }
+//end sandywalker 2024-04-30
             }
             if (loaderClassName != null) {
                 return (LibraryLoader) Class.forName(loaderClassName).getDeclaredConstructor().newInstance();

--- a/rapidocr/src/main/resources/load/loaders.properties
+++ b/rapidocr/src/main/resources/load/loaders.properties
@@ -4,6 +4,7 @@ onnx.mac-x86_64=io.github.mymonstercat.OnnxMacX8664LibraryLoader
 onnx.win-x86=io.github.mymonstercat.OnnxWindowsX86LibraryLoader
 onnx.win-x86_64=io.github.mymonstercat.OnnxWindowsX8664LibraryLoader
 onnx.linux-x86_64=io.github.mymonstercat.OnnxLinuxX8664LibraryLoader
+onnx.linux-arm64=io.github.mymonstercat.OnnxLinuxArm64LibraryLoader
 onnx.model=io.github.mymonstercat.OnnxModelsLoader
 # NCNN
 ncnn.mac-arm64=io.github.mymonstercat.NcnnMacArm64LibraryLoader


### PR DESCRIPTION
您好，主要修改内容如下：
增加模块 rapidocr-onnx-linux-arm64
修改 LoadUtil 支持 arm64 linux 库加载
更新 loaders.properties  增加 onnx.linux-arm64=io.github.mymonstercat.OnnxLinuxArm64LibraryLoader
编写银河麒麟 kylin linux arm…64 编译构建文档

本次修改已编写测试程序在 银河麒麟 v10 arm64 机器上通过，Ocr 功能正常。